### PR TITLE
incorrect sparql redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Virtuoso files /data/db
 /data/db/*
+/data/ldes-consumer/*
 /data/authorization/*
 /data/db/virtuoso.ini
 !/data/db/toLoad
 !/data/db/toLoad/*
-
+.env
 docker-compose.override.yml

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -12,7 +12,7 @@ defmodule Dispatcher do
     |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
     |> send_resp( 200, "{ \"message\": \"ok\" }" )
   end
-  define_layers [ :static, :sparql, :api_services, :frontend_fallback, :resources, :not_found ]
+  define_layers [ :static, :sparql, :frontend_fallback]
 
   # frontend
   match "/index.html", %{ layer: :static } do
@@ -27,7 +27,8 @@ defmodule Dispatcher do
     forward conn, path, "http://frontend/@appuniversum/"
   end
 
-  match "/sparql", %{ layer: :static } do
+
+  get "/sparql", %{ layer: :static, accept: %{ html: true} } do
     forward conn, [], "http://frontend/index.html"
   end
 
@@ -57,7 +58,7 @@ defmodule Dispatcher do
 
 
   
-  match "/*path", %{ layer: :frontend_fallback, accept: %{ html: true } } do
+  match "/*path", %{ layer: :frontend_fallback, accept: %{ any: true } } do
     forward conn, [], "http://frontend/index.html"
   end
 end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -27,6 +27,9 @@ defmodule Dispatcher do
     forward conn, path, "http://frontend/@appuniversum/"
   end
 
+  match "/sparql", %{ layer: :static } do
+    forward conn, [], "http://frontend/index.html"
+  end
 
   ###############
   # SPARQL


### PR DESCRIPTION
when refreshing the home page, instead of being redirected to the yasgui ui, you get a json response:
```json
{"status":500,"message":"Failed to process query.","mu-call-id":"848557661903","mu-call-id-trail":[],"mu-session-id":"http://mu.semte.ch/sessions/6f87620c-1453-11f0-89f4-0242ac170008","mu-auth-sudo":[],"mu-auth-allowed-groups":"[{\"name\":\"public\",\"variables\":[]}]","mu-call-scope":"_","internal-error":"The value NIL is not of type (OR STRING (SIMPLE-ARRAY (UNSIGNED-BYTE 8) (*))) when binding QURI.DECODE::DATA","source-ip":"172.20.0.11"}